### PR TITLE
eslint ignore built files in abacus-components

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 packages/**/node_modules
+packages/abacus-components/lib/**


### PR DESCRIPTION
This PR resolves eslint  issues during build/dev by ignoring the code in the generated esm/cjs files of abacus-components