### PR TITLE
Updating gatsby.node.js to handle polyfills

### DIFF
--- a/packages/abacus-pools/gatsby-node.js
+++ b/packages/abacus-pools/gatsby-node.js
@@ -1,10 +1,27 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin")
+// eslint-disable-next-line import/no-extraneous-dependencies
+const webpack = require("webpack")
 
 exports.onCreateWebpackConfig = ({ actions }) => {
   actions.setWebpackConfig({
+    plugins: [
+      new webpack.ProvidePlugin({
+        process: "process",
+        Buffer: ["buffer", "Buffer"],
+      }),
+    ],
     resolve: {
       plugins: [new TsconfigPathsPlugin()],
+      fallback: {
+        crypto: require.resolve("crypto-browserify"),
+        stream: require.resolve("stream-browserify"),
+        assert: require.resolve("assert"),
+        http: require.resolve("stream-http"),
+        https: require.resolve("https-browserify"),
+        os: require.resolve("os-browserify"),
+        url: require.resolve("url"),
+      },
     },
   })
 }


### PR DESCRIPTION
This PR resolves build issues in abacus-pools by updating gatsby.node.js to handle polyfills (which were handled automatically before webpack v5, since our upgrade to gatsby v4, we are now using webpack v5)